### PR TITLE
Add observers for TSC meetings

### DIFF
--- a/examples/tsc.sh
+++ b/examples/tsc.sh
@@ -18,6 +18,7 @@ INVITEES="\
 * Shigeki Ohtsu @shigeki (TSC)
 * Trevor Norris @trevnorris (TSC)
 * William Kapke @williamkapke (observer)
+* Jenn Turner @renrutnnej (observer)
 "
 JOINING_INSTRUCTIONS="Uberconference; participants should have the link & numbers, contact me if you don't.
 

--- a/examples/tsc.sh
+++ b/examples/tsc.sh
@@ -19,6 +19,7 @@ INVITEES="\
 * Trevor Norris @trevnorris (TSC)
 * William Kapke @williamkapke (observer)
 * Jenn Turner @renrutnnej (observer)
+* Tracy Hinds @hackygolucky(observer/Node.js Foundation)
 "
 JOINING_INSTRUCTIONS="Uberconference; participants should have the link & numbers, contact me if you don't.
 


### PR DESCRIPTION
Add:
- Jenn Turner as observer for TSC meetings. She'll be writing the weekly Node news and it is helpful to ensure accuracy of speakers.
- Tracy Hinds as Node.js Foundation observer to help coordinate efforts between the Foundation and the TSC.