### PR TITLE
remove departed Node.js Foundation staff

### DIFF
--- a/examples/ctc.sh
+++ b/examples/ctc.sh
@@ -28,7 +28,6 @@ INVITEES="\
 * Bradley Meck @bmeck (GoDaddy/TC39)
 * Tracy Hinds @hackygolucky (Node.js Foundation Education Community Manager)
 * Josh Gavant @joshgav (Microsoft)
-* Mikeal Rogers @mikeal (Node.js Foundation Community Manager)
 * Mark Hinkle @mrhinkle (Node.js Foundation Executive Director)
 * Jenn Turner @renrutnnej (Node.js Foundation Newsletter Curator)
 "


### PR DESCRIPTION
After consulting with him, removing Mikeal from the CTC invite list. (@mhdawson and @nebrius, you might want to do the same for CommComm and TSC.)